### PR TITLE
add lazyloading option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,6 @@
 var EngineAddon = require('ember-engines/lib/engine-addon');
 
 module.exports = EngineAddon.extend({
-  name: 'ember-handoff'
+  name: 'ember-handoff',
+  lazyLoading: false
 });


### PR DESCRIPTION
Per https://github.com/dgeb/ember-engines#lazy-loading-engines Engines must include the `lazyloading` option in the index.js. This flag must be set to `false` until lazyloading support is added to engines. This prevents a deprecation warning.
